### PR TITLE
connection: ignore window updates after end stream

### DIFF
--- a/lib/spdy-transport/connection.js
+++ b/lib/spdy-transport/connection.js
@@ -307,6 +307,10 @@ Connection.prototype._handleFrame = function _handleFrame (frame) {
       // Other side should destroy the stream upon receiving GOAWAY
       if (this._isGoaway(frame.id)) { return }
 
+      // Ignore WINDOW_UPDATE frames from closed streams
+      if (frame.type === 'WINDOW_UPDATE' &&
+          frame.id <= state.stream.lastId.received) { return }
+
       state.debug('id=0 stream=%d not found', frame.id)
       state.framer.rstFrame({ id: frame.id, code: 'INVALID_STREAM' })
       return

--- a/test/both/transport/connection-test.js
+++ b/test/both/transport/connection-test.js
@@ -294,6 +294,30 @@ describe('Transport/Connection', function () {
       })
     })
 
+    it('should ignore WINDOW_UPDATE frame after END_STREAM', function (done) {
+      client.request({
+        path: '/hello'
+      }, function (err, stream) {
+        assert(!err)
+
+        stream.resume()
+
+        stream.once('close', function () {
+          client.on('frame', function (frame) {
+            assert(!(frame.type === 'RST' && frame.id === 1))
+          })
+
+          client._spdyState.framer.windowUpdateFrame({
+            id: stream.id,
+            delta: 1
+          }, function (err) {
+            assert(!err)
+            setTimeout(done, 10)
+          })
+        })
+      })
+    })
+
     it('should use last received id when killing streams', function (done) {
       var waiting = 2
       function next () {


### PR DESCRIPTION
👋 Hi & thanks for the awesome module! I recently ran into an issue with a client that seemed to sometimes have a race condition where `spdy-transport` would receive a `WINDOW_UPDATE` frame on a stream that the server (run using `spdy-transport`) had ended. This seems to have been network queuing quirks or something.

After banging my head for a while, I realized that the `spdy-transport` as a server should probably just be ignoring those frames, at least from my read through of the specs (and NGINX seems to be doing just that).

Here is what I found in the HTTP/2 spec (https://tools.ietf.org/html/rfc7540#section-6.9):

>    WINDOW_UPDATE can be sent by a peer that has sent a frame bearing the
   END_STREAM flag.  This means that a receiver could receive a
   WINDOW_UPDATE frame on a "half-closed (remote)" or "closed" stream.
   A receiver MUST NOT treat this as an error (see Section 5.1).

I don't know a lot about SPDY, and so not sure if the change should be applied to the SPDY versions. I tried to look a little bit and saw the following in https://www.chromium.org/spdy/spdy-protocol/spdy-protocol-draft3#TOC-2.6.8-WINDOW_UPDATE :

> A sender should ignore all the WINDOW_UPDATE frames associated with the stream after it send the last frame for the stream.

I'm not 100% sure I'm interpreting this correctly, and even if I am, not sure if the approach I took in this PR is the best solution for your architecture :) but maybe it is or you have some pointers.