### PR TITLE
bug: remove `windowBits : 0`

### DIFF
--- a/lib/spdy-transport/protocol/spdy/zlib-pool.js
+++ b/lib/spdy-transport/protocol/spdy/zlib-pool.js
@@ -24,8 +24,7 @@ function createDeflate (version, compression) {
 function createInflate (version) {
   var inflate = zlib.createInflate({
     dictionary: transport.protocol.spdy.dictionary[version],
-    flush: zlib.Z_SYNC_FLUSH,
-    windowBits: 0
+    flush: zlib.Z_SYNC_FLUSH
   })
 
   // For node.js v0.8


### PR DESCRIPTION
It has always been an invalid option that got replaced with `Z_DEFAULT_WINDOWBITS`

Since https://github.com/nodejs/node/commit/9e4660b5187d4be6a1484e705dc735c0e76ffafa it will throw.

Ref: [Failing CITGM report](https://ci.nodejs.org/job/citgm-smoker/811/nodes=ubuntu1404-64/testReport/(root)/citgm/spdy_transport_v2_0_18/)