### PR TITLE
fix: usage of Object.assign

### DIFF
--- a/lib/spdy-transport/protocol/http2/constants.js
+++ b/lib/spdy-transport/protocol/http2/constants.js
@@ -3,13 +3,7 @@
 var transport = require('../../../spdy-transport')
 var base = transport.protocol.base
 
-var util = require('util')
 var Buffer = require('safe-buffer').Buffer
-
-// Node.js 0.8, 0.10 and 0.12 support
-Object.assign = process.versions.modules >= 46
-  ? Object.assign // eslint-disable-next-line
-  : util._extend
 
 exports.PREFACE_SIZE = 24
 exports.PREFACE = 'PRI * HTTP/2.0\r\n\r\nSM\r\n\r\n'

--- a/lib/spdy-transport/protocol/spdy/framer.js
+++ b/lib/spdy-transport/protocol/spdy/framer.js
@@ -12,11 +12,6 @@ var WriteBuffer = require('wbuf')
 
 var debug = require('debug')('spdy:framer')
 
-// Node.js 0.8, 0.10 and 0.12 support
-Object.assign = process.versions.modules >= 46
-  ? Object.assign // eslint-disable-next-line
-  : util._extend
-
 function Framer (options) {
   base.Framer.call(this, options)
 }

--- a/lib/spdy-transport/stream.js
+++ b/lib/spdy-transport/stream.js
@@ -12,11 +12,6 @@ var debug = {
 var Buffer = require('safe-buffer').Buffer
 var Duplex = require('readable-stream').Duplex
 
-// Node.js 0.8, 0.10 and 0.12 support
-Object.assign = process.versions.modules >= 46
-  ? Object.assign // eslint-disable-next-line
-  : util._extend
-
 function Stream (connection, options) {
   Duplex.call(this)
 

--- a/lib/spdy-transport/utils.js
+++ b/lib/spdy-transport/utils.js
@@ -1,6 +1,12 @@
 'use strict'
 
 var util = require('util')
+var isNode = require('detect-node')
+
+// Node.js 0.8, 0.10 and 0.12 support
+Object.assign = (process.versions.modules >= 46 || !isNode)
+  ? Object.assign // eslint-disable-next-line
+  : util._extend
 
 function QueueItem () {
   this.prev = null

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   "author": "Fedor Indutny <fedor@indutny.com>",
   "dependencies": {
     "debug": "^2.6.8",
+    "detect-node": "^2.0.3",
     "hpack.js": "^2.1.6",
     "obuf": "^1.1.1",
     "readable-stream": "^2.2.9",


### PR DESCRIPTION
I introduced a bug when I migrated this module to Standard 10, but remapping Object.assign globally, it worked for Node.js, but it would break the usage in the browser, as the check was only being done for Node.js versions.