### PR TITLE
for h2 make sure it follows http messaging from spec

### DIFF
--- a/lib/spdy-transport/stream.js
+++ b/lib/spdy-transport/stream.js
@@ -25,6 +25,7 @@ function Stream (connection, options) {
   this.path = options.path
   this.host = options.host
   this.headers = options.headers || {}
+  this.headersSent = false
   this.connection = connection
   this.parent = options.parent || null
 
@@ -354,13 +355,20 @@ Stream.prototype._onFinish = function _onFinish () {
       })
       return
     }
-
-    state.framer.dataFrame({
-      id: this.id,
-      priority: state.priority.getPriority(),
-      fin: true,
-      data: new Buffer(0)
-    })
+    if (this.trailers) {
+      state.framer.headersFrame({
+        id: this.id,
+        headers: this.trailers,
+        fin: true
+      })
+    } else {
+      state.framer.dataFrame({
+        id: this.id,
+        priority: state.priority.getPriority(),
+        fin: true,
+        data: Buffer.alloc(0)
+      })
+    }
   }
 
   this._maybeClose()
@@ -510,6 +518,8 @@ Stream.prototype.send = function send (callback) {
     this._writableState.finished = true
   }
 
+  this.headersSent = true
+
   // TODO(indunty): ideally it should just take a stream object as an input
   var self = this
   this._hardCork()
@@ -546,6 +556,9 @@ Stream.prototype.respond = function respond (status, headers, callback) {
     status: status,
     headers: headers
   }
+
+  this.headersSent = true
+
   this._hardCork()
   state.framer.responseFrame(frame, function (err) {
     self._hardUncork()
@@ -597,14 +610,19 @@ Stream.prototype.sendHeaders = function sendHeaders (headers, callback) {
     return
   }
 
-  this._hardCork()
-  state.framer.headersFrame({
-    id: this.id,
-    headers: headers
-  }, function (err) {
-    self._hardUncork()
-    if (callback) { callback(err) }
-  })
+  if (state.protocol.name !== 'h2' || this.headersSent === false) {
+    this.headersSent = true
+    this._hardCork()
+    state.framer.headersFrame({
+      id: this.id,
+      headers: headers
+    }, function (err) {
+      self._hardUncork()
+      if (callback) { callback(err) }
+    })
+  } else {
+    this.trailers = headers
+  }
 }
 
 Stream.prototype.destroy = function destroy () {

--- a/test/both/transport/stream-test.js
+++ b/test/both/transport/stream-test.js
@@ -122,7 +122,6 @@ describe('Transport/Stream', function () {
         stream.sendHeaders({ a: 'b' })
         stream.end()
       })
-
       server.on('stream', function (stream) {
         var gotHeaders = false
         stream.on('headers', function (headers) {
@@ -350,6 +349,7 @@ describe('Transport/Stream', function () {
     })
 
     it('should emit trailing headers', function (done) {
+      let dataReceived = false
       client.request({
         method: 'POST',
         path: '/hello-split'
@@ -364,11 +364,25 @@ describe('Transport/Stream', function () {
         })
       })
 
+      if (name === 'h2') {
+        server.on('frame', function (frame) {
+          if (frame.type === 'HEADERS' && dataReceived) {
+            assert.ok(frame.fin)
+          }
+        })
+      }
+
       server.on('stream', function (stream) {
         stream.respond(200, {})
 
         stream.resume()
+        stream.on('data', (data) => {
+          dataReceived = true
+        })
         stream.on('headers', function (headers) {
+          if (name === 'h2') {
+            assert.ok(dataReceived)
+          }
           assert.equal(headers.trailer, 'yes')
           done()
         })


### PR DESCRIPTION
According to the SPDY spec HEADER frames were allowed to be interleaved with DATA frames but with HTTP/2 it must follow the HTTP semantics lined out here:

https://tools.ietf.org/html/draft-ietf-httpbis-http2-17#section-8

Which basically says:

1. Stream starts with a HEADER frame
2. Stream can can contain one or more DATA frames
3. Stream can can optionally have one HEADER frame at the end of the stream and the FIN flag must be set to true.

I ran into this issue when trying to use a node-spdy client against a node v10 server running node's native HTTP/2 server and the server was returning trailers.